### PR TITLE
Update server.R

### DIFF
--- a/server.R
+++ b/server.R
@@ -402,6 +402,10 @@ shinyServer(function(input, output, session) {
 		write.csv(dataM(), file, row.names=FALSE)
     }) ###
 
+	session$onSessionEnded(function() {
+    stopApp()
+  })
+	
 })
 
 


### PR DESCRIPTION
The addition of stopApp() will ensure that when user closes the window when running the session locally, the shiny app and the server will be terminated. It is most visible when running from R Console or from Terminal using Rscript, which are still busy even after user closes the browser tab.

I should probably add that this shouldn't be added to a publicly accessible, server-deployed app since closing the window will kill the whole app for every on-line user.